### PR TITLE
[incompatible] Support context more on Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7
+- 1.8
 - tip
 script:
 - make lint

--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ func init() {
 	DefaultClient, _, _ = NewClient()
 }
 
-func safeAddr(hostport string) (string, error) {
+func safeAddr(ctx context.Context, hostport string) (string, error) {
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
 		return "", err
@@ -52,16 +52,16 @@ func safeAddr(hostport string) (string, error) {
 		return "", fmt.Errorf("bad host is detected: %v", host)
 	}
 
-	ips, err := net.LookupIP(host) // TODO timeout
-	if err != nil || len(ips) <= 0 {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil || len(addrs) <= 0 {
 		return "", err
 	}
-	for _, ip := range ips {
-		if ip.To4() != nil && isBadIPv4(ip) {
-			return "", fmt.Errorf("bad ip is detected: %v", ip)
+	for _, addr := range addrs {
+		if addr.IP.To4() != nil && isBadIPv4(addr.IP) {
+			return "", fmt.Errorf("bad ip is detected: %v", addr.IP)
 		}
 	}
-	return net.JoinHostPort(ips[0].String(), port), nil
+	return net.JoinHostPort(addrs[0].IP.String(), port), nil
 }
 
 // NewDialer returns a dialer function which only allows IPv4 connections.
@@ -72,7 +72,7 @@ func NewDialer(dialer *net.Dialer) func(ctx context.Context, network, addr strin
 	return func(ctx context.Context, network, hostport string) (net.Conn, error) {
 		switch network {
 		case "tcp", "tcp4":
-			addr, err := safeAddr(hostport)
+			addr, err := safeAddr(ctx, hostport)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The `net.Resolver.LookupIPAddr` accepts `context` on Go 1.8 or later and we can handle DNS timeout with it.

[notice]
In this pull request, Go 1.7 support is dropped.