### PR TITLE
Fix IPv6 unspecified address

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,7 +121,7 @@ func safeAddr(ctx context.Context, resolver *net.Resolver, hostport string, opts
 
 	ip := net.ParseIP(host)
 	if ip != nil {
-		if ip.To4() != nil && c.isIPForbidden(ip) {
+		if ip.IsUnspecified() || (ip.To4() != nil && c.isIPForbidden(ip)) {
 			return "", fmt.Errorf("bad ip is detected: %v", ip)
 		}
 		return net.JoinHostPort(ip.String(), port), nil

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,10 @@ func TestRequest(t *testing.T) {
 	if _, err := DefaultClient.Get("http://192.168.0.1"); err == nil {
 		t.Errorf("The request for localhost should be fail")
 	}
+
+	if _, err := DefaultClient.Get("http://[::]"); err == nil {
+		t.Errorf("The request for IPv6 unspecified address should be fail")
+	}
 }
 
 func TestIsHostForbidden(t *testing.T) {


### PR DESCRIPTION
Go translates IPv6 unspecified address to IPv4 (0.0.0.0). This PR fixes that.