### PR TITLE
introduce GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: test
+
 on:
   push:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version:
+          - "1.20"
+          - "1.19"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,31 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go-version:
+        go:
           - "1.20"
           - "1.19"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
-      - run: make test
+          go-version: ${{ matrix.go }}
+
+      - run: go test -v -coverprofile=profile.cov ./...
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov
+          flag-name: Go-${{ matrix.go }}
+          parallel: true
+
+  # notifies that all test jobs are finished.
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-- "1.12"
-- tip
-script:
-- make lint
-- make test
-after_script:
-- make cover

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Paranoidhttp
 
-[![Build Status](https://travis-ci.org/hakobe/paranoidhttp.svg?branch=master)][travis]
+[![test](https://github.com/hakobe/paranoidhttp/actions/workflows/test.yml/badge.svg)](https://github.com/hakobe/paranoidhttp/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/hakobe/paranoidhttp/badge.svg?branch=master)][coveralls]
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
 [![GoDoc](https://godoc.org/github.com/hakobe/paranoidhttp?status.svg)][godoc]


### PR DESCRIPTION
It looks that CI on Travis-CI doesn't work https://app.travis-ci.com/hakobe/paranoidhttp.
I propose to migrate [GitHub Actions](https://github.com/features/actions).