### PR TITLE
migrate godoc.org to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Build Status](https://travis-ci.org/hakobe/paranoidhttp.svg?branch=master)][travis]
 [![Coverage Status](https://coveralls.io/repos/hakobe/paranoidhttp/badge.svg?branch=master)][coveralls]
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
-[![GoDoc](https://godoc.org/github.com/hakobe/paranoidhttp?status.svg)][godoc]
+[![GoDoc](https://pkg.go.dev/badge/github.com/hakobe/paranoidhttp)][godoc]
 
 [travis]: https://travis-ci.org/hakobe/paranoidhttp
 [coveralls]: https://coveralls.io/r/hakobe/paranoidhttp?branch=master
 [license]: https://github.com/hakobe/paranoidhttp/blob/master/LICENSE
-[godoc]: https://godoc.org/github.com/hakobe/paranoidhttp
+[godoc]: https://pkg.go.dev/github.com/hakobe/paranoidhttp
 
 Paranoidhttp provides a pre-configured http.Client that protects you from harm.
 


### PR DESCRIPTION
All requests to godoc.org are now redirected to pkg.go.dev.
We should point pkg.go.dev directly.