### PR TITLE
Allow extending the default forbidden IPNets instead of replacing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ dialer.KeepAlive = 60 * time.Second
 ipNet, _ := net.ParseCIDR("127.0.0.1/32")
 client, _, _ := paranoidhttp.New(
     paranoidhttp.PermittedIPNets(ipNet))
+
+// Extend the default forbidden ipnets instead of replacing them
+_, extraNet, _ := net.ParseCIDR("100.64.0.0/10")
+client, _, _ := paranoidhttp.NewClient(
+    paranoidhttp.AddForbiddenIPNets(extraNet))
+
+// Inspect the default forbidden ipnets
+defaults := paranoidhttp.DefaultForbiddenIPNets()
 ```
 
 ## Acknowledgement

--- a/client.go
+++ b/client.go
@@ -103,13 +103,33 @@ func basicConfig() *config {
 	return &c
 }
 
+// DefaultForbiddenIPNets returns a copy of the IPNets that are forbidden by
+// default, so callers can inspect or build on them without redeclaring the
+// CIDRs that paranoidhttp already blocks.
+func DefaultForbiddenIPNets() []*net.IPNet {
+	ips := make([]*net.IPNet, len(defaultConfig.ForbiddenIPNets))
+	copy(ips, defaultConfig.ForbiddenIPNets)
+	return ips
+}
+
 // Option type of paranoidhttp
 type Option func(*config)
 
-// ForbiddenIPNets sets forbidden IPNets
+// ForbiddenIPNets replaces the forbidden IPNets entirely, discarding the
+// default list. Use AddForbiddenIPNets to extend the defaults instead.
 func ForbiddenIPNets(ips ...*net.IPNet) Option {
 	return func(c *config) {
 		c.ForbiddenIPNets = ips
+	}
+}
+
+// AddForbiddenIPNets appends ips to the existing forbidden IPNets instead of
+// replacing them, so the default list stays in effect alongside the
+// additions. If combined with ForbiddenIPNets, order matters: apply
+// ForbiddenIPNets first to start from a known base.
+func AddForbiddenIPNets(ips ...*net.IPNet) Option {
+	return func(c *config) {
+		c.ForbiddenIPNets = append(c.ForbiddenIPNets, ips...)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -108,3 +108,34 @@ func TestIsIpForbidden(t *testing.T) {
 		t.Errorf("%s should not be forbidden", ip)
 	}
 }
+
+func TestDefaultForbiddenIPNets(t *testing.T) {
+	defaults := DefaultForbiddenIPNets()
+	if len(defaults) != len(defaultConfig.ForbiddenIPNets) {
+		t.Fatalf("expected %d default forbidden IPNets, got %d", len(defaultConfig.ForbiddenIPNets), len(defaults))
+	}
+
+	// mutating the returned slice must not affect the real defaults
+	defaults[0] = mustParseCIDR("8.8.8.8/32")
+	if defaultConfig.ForbiddenIPNets[0].String() == defaults[0].String() {
+		t.Errorf("DefaultForbiddenIPNets should return a copy, not a reference to the internal slice")
+	}
+}
+
+func TestAddForbiddenIPNets(t *testing.T) {
+	c := basicConfig()
+	extra := mustParseCIDR("203.0.113.0/24") // TEST-NET-3, not blocked by default
+	if c.isIPForbidden(net.ParseIP("203.0.113.1")) {
+		t.Fatalf("203.0.113.1 should not be forbidden by default")
+	}
+
+	AddForbiddenIPNets(extra)(c)
+
+	if !c.isIPForbidden(net.ParseIP("203.0.113.1")) {
+		t.Errorf("203.0.113.1 should be forbidden after AddForbiddenIPNets")
+	}
+	// defaults should still be in effect
+	if !c.isIPForbidden(net.ParseIP("10.0.0.1")) {
+		t.Errorf("10.0.0.1 should still be forbidden by the defaults")
+	}
+}


### PR DESCRIPTION
Add AddForbiddenIPNets to append to the default list, and. DefaultForbiddenIPNets to expose it for inspection.

I was working base off of unified push's SSRF protection using this library and needed to add a few extra blocked CIDRs on top of paranoidhttp's defaults.

But ForbiddenIPNets replaces the list wholesale, and the default list itself isn't exported, so the only way to extend it was to redeclare paranoidhttp's internal CIDRs in first, then add mine to that copy. This change lets you extend the defaults directly instead of duplicating them.